### PR TITLE
sanitize and WPCS ignore nonce verification

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -111,7 +111,8 @@ class Plugin {
 	 * @action load-tools_page_updates-api-inspector
 	 */
 	function maybe_do_update_check() {
-		$current = isset( $_REQUEST['type'] ) ? $_REQUEST['type'] : '';
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$current = isset( $_REQUEST['type'] ) && in_array( $_REQUEST['type'], [ 'core', 'plugins' , 'themes' ], true ) ? un_slash( $_REQUEST['type'] ) : '';
 		if ( $current ) {
 			check_admin_referer( 'updates-api-inspector' );
 

--- a/plugin.php
+++ b/plugin.php
@@ -112,7 +112,7 @@ class Plugin {
 	 */
 	function maybe_do_update_check() {
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$current = isset( $_REQUEST['type'] ) && in_array( $_REQUEST['type'], [ 'core', 'plugins' , 'themes' ], true ) ? un_slash( $_REQUEST['type'] ) : '';
+		$current = isset( $_REQUEST['type'] ) && in_array( $_REQUEST['type'], [ 'core', 'plugins' , 'themes' ], true ) ? wp_unslash( $_REQUEST['type'] ) : '';
 		if ( $current ) {
 			check_admin_referer( 'updates-api-inspector' );
 

--- a/plugin.php
+++ b/plugin.php
@@ -112,7 +112,7 @@ class Plugin {
 	 */
 	function maybe_do_update_check() {
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$current = isset( $_REQUEST['type'] ) && in_array( $_REQUEST['type'], [ 'core', 'plugins' , 'themes' ], true ) ? wp_unslash( $_REQUEST['type'] ) : '';
+		$current = isset( $_REQUEST['type'] ) && in_array( $_REQUEST['type'], array( 'core', 'plugins' , 'themes' ), true ) ? wp_unslash( $_REQUEST['type'] ) : '';
 		if ( $current ) {
 			check_admin_referer( 'updates-api-inspector' );
 


### PR DESCRIPTION
can safely ignore nonce verification as we are explicitly testing the variable