### PR TITLE
Fix pretty_print() indentation

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -871,7 +871,7 @@ class Plugin {
 			<div class='notice notice-warning inline'>
 				<p>
 						<?php
-						echo '<strong>' . esc_html__( 'Important', 'updates-api-inspector' ) . '</strong>:&nbsp;' .
+						echo '<strong>' . esc_html__( 'Important', 'updates-api-inspector' ) . '</strong>:' .
 							sprintf(
 								/* translators: variable name */
 								esc_html__( 'The Auto-updates UI, introduced in WordPress 5.5.0, will not work correctly for externally hosted plugins that do not populate %s with information about their plugin!', 'updates-api-inspector' ),
@@ -957,7 +957,7 @@ class Plugin {
 			<div class='notice notice-warning inline'>
 				<p>
 						<?php
-						echo '<strong>' . esc_html__( 'Important', 'updates-api-inspector' ) . '</strong>:&nbsp;' .
+						echo '<strong>' . esc_html__( 'Important', 'updates-api-inspector' ) . '</strong>:' .
 							sprintf(
 								/* translators: variable name */
 								esc_html__( 'The Auto-updates UI, introduced in WordPress 5.5.0, will not work correctly for externally hosted themes that do not populate %s with information about their theme!', 'updates-api-inspector' ),

--- a/plugin.php
+++ b/plugin.php
@@ -1246,12 +1246,16 @@ class Plugin {
 				'/array\s+\(/', // for some arrays, var_export() adds the extra whitespace, others it doesn't.
 				'/\d+ =>\s+/',  // strip numeric indexes from arrays.
 				'/\(\s+\)/',    // ensure empty arrays appear on 1 line.
+				'/\(array\(/',  // Ensure opening parenthesis of a multi-line function call is the last content on the line.
+				'/\)\)/',       // Ensure closing parenthesis of a multi-line function call is the last content on the line.
 			),
 			array(
 				'=> ',
 				'array(',
 				'',
 				'()',
+				"(\narray(",
+				")\n)",
 			),
 			$str
 		);

--- a/plugin.php
+++ b/plugin.php
@@ -871,7 +871,7 @@ class Plugin {
 			<div class='notice notice-warning inline'>
 				<p>
 						<?php
-						echo '<strong>' . esc_html__( 'Important', 'updates-api-inspector' ) . '</strong>:' .
+						echo '<strong>' . esc_html__( 'Important', 'updates-api-inspector' ) . '</strong>:&nbsp;' .
 							sprintf(
 								/* translators: variable name */
 								esc_html__( 'The Auto-updates UI, introduced in WordPress 5.5.0, will not work correctly for externally hosted plugins that do not populate %s with information about their plugin!', 'updates-api-inspector' ),
@@ -957,7 +957,7 @@ class Plugin {
 			<div class='notice notice-warning inline'>
 				<p>
 						<?php
-						echo '<strong>' . esc_html__( 'Important', 'updates-api-inspector' ) . '</strong>:' .
+						echo '<strong>' . esc_html__( 'Important', 'updates-api-inspector' ) . '</strong>:&nbsp;' .
 							sprintf(
 								/* translators: variable name */
 								esc_html__( 'The Auto-updates UI, introduced in WordPress 5.5.0, will not work correctly for externally hosted themes that do not populate %s with information about their theme!', 'updates-api-inspector' ),

--- a/plugin.php
+++ b/plugin.php
@@ -1242,12 +1242,12 @@ class Plugin {
 
 		$str = preg_replace(
 			array(
-				'/=>\s+/',      // this includes newlines and leading whitespace on the next line.
-				'/array\s+\(/', // for some arrays, var_export() adds the extra whitespace, others it doesn't.
-				'/\d+ =>\s+/',  // strip numeric indexes from arrays.
-				'/\(\s+\)/',    // ensure empty arrays appear on 1 line.
-				'/\(array\(/',  // Ensure opening parenthesis of a multi-line function call is the last content on the line.
-				'/\)\)/',       // Ensure closing parenthesis of a multi-line function call is the last content on the line.
+				'/=>\s+/',      // This includes newlines and leading whitespace on the next line.
+				'/array\s+\(/', // For some arrays, var_export() adds the extra whitespace, others it doesn't.
+				'/\d+ =>\s+/',  // Strip numeric indexes from arrays.
+				'/\(\s+\)/',    // Ensure empty arrays appear on 1 line.
+				'/\(array\(/',  // Ensure opening parenthesis of a multi-line function call is the last content on the line as in WPCS.
+				'/\)\)/',       // Ensure closing parenthesis of a multi-line function call is the last content on the line as in WPCS.
 			),
 			array(
 				'=> ',

--- a/plugin.php
+++ b/plugin.php
@@ -1242,10 +1242,10 @@ class Plugin {
 
 		$str = preg_replace(
 			array(
-				'/=>\s+/',      // This includes newlines and leading whitespace on the next line.
-				'/array\s+\(/', // For some arrays, var_export() adds the extra whitespace, others it doesn't.
-				'/\d+ =>\s+/',  // Strip numeric indexes from arrays.
-				'/\(\s+\)/',    // Ensure empty arrays appear on 1 line.
+				'/=>\s+/',      // this includes newlines and leading whitespace on the next line.
+				'/array\s+\(/', // for some arrays, var_export() adds the extra whitespace, others it doesn't.
+				'/\d+ =>\s+/',  // strip numeric indexes from arrays.
+				'/\(\s+\)/',    // ensure empty arrays appear on 1 line.
 				'/\(array\(/',  // Ensure opening parenthesis of a multi-line function call is the last content on the line as in WPCS.
 				'/\)\)/',       // Ensure closing parenthesis of a multi-line function call is the last content on the line as in WPCS.
 			),


### PR DESCRIPTION
Fix #7 

Check the above issue for detailed description.

Add a linebreak in both `(array(` and `))` strings so `pretty_print()` can find the the currently closing `)),` lines and reduce indent correctly. It outputs valid WPCS code. :)